### PR TITLE
25 remaining errors and 9 can be fixed by unsafe fix by ruff:

### DIFF
--- a/contracts/cosmwasm/order/.devenv/profile
+++ b/contracts/cosmwasm/order/.devenv/profile
@@ -1,1 +1,1 @@
-/nix/store/qhq84xind06z73abs3486szc61cj3d71-devenv-profile
+D:/nix/store/qhq84xind06z73abs3486szc61cj3d71-devenv-profile

--- a/contracts/evm/.devenv/profile
+++ b/contracts/evm/.devenv/profile
@@ -1,1 +1,1 @@
-/nix/store/yj6rc7jpj9pww0ifvhrrwpghirai5c1y-devenv-profile
+D:/nix/store/yj6rc7jpj9pww0ifvhrrwpghirai5c1y-devenv-profile

--- a/crates/cvm-runtime/.devenv/profile
+++ b/crates/cvm-runtime/.devenv/profile
@@ -1,1 +1,1 @@
-/nix/store/qhq84xind06z73abs3486szc61cj3d71-devenv-profile
+D:/nix/store/qhq84xind06z73abs3486szc61cj3d71-devenv-profile

--- a/mantis/.devenv/profile
+++ b/mantis/.devenv/profile
@@ -1,1 +1,1 @@
-/nix/store/l14ylsbspqnjli59l42m5r9ym5igkj5j-devenv-profile
+D:/nix/store/l14ylsbspqnjli59l42m5r9ym5igkj5j-devenv-profile

--- a/mantis/blackbox/joiner.py
+++ b/mantis/blackbox/joiner.py
@@ -1,6 +1,4 @@
 # this is up to take production data in heterogenous shape, and force it into pandas dataframe(s)
-from blackbox.models import AllData
-import pandas as pd
 from blackbox.cvm_runtime.execute import (
     AssetId,
     AssetItem,

--- a/mantis/blackbox/main.py
+++ b/mantis/blackbox/main.py
@@ -1,30 +1,22 @@
-from typing import Dict
 
 # from fastapi_cache import FastAPICache
 # from fastapi_cache.decorator import cache
 # from fastapi_cache.backends.inmemory import InMemoryBackend
-from blackbox.cvm_runtime.response_to_get_config import GetConfigResponse
 from blackbox.models import (
     AllData,
-    CosmosChains,
-    NeutronPoolsResponse,
     OsmosisPoolsResponse,
 )
-from blackbox.neutron_pools import Model as NeutronPoolsModel
 from blackbox.settings import settings
 from cosmpy.aerial.config import NetworkConfig
-from cosmpy.aerial.contract import LedgerClient, LedgerContract
+from cosmpy.aerial.contract import LedgerClient
 from fastapi import FastAPI
-import blackbox.cvm_runtime.query as cvm_query
 import requests
 import uvicorn
 from simulation.routers import test_bruno
 from simulation.routers import data
 import sys
 import os
-from typing import List
 from pydantic import BaseModel
-import pandas as pd
 from simulation.routers.data import read_dummy_data, AllData as CvmAllData
 
 app = FastAPI()

--- a/mantis/blackbox/settings.py
+++ b/mantis/blackbox/settings.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/mantis/pyproject.toml
+++ b/mantis/pyproject.toml
@@ -65,6 +65,11 @@ PySCIPOpt = "4.4.0" # i set it directly to allow override SCIP dep (currently it
 pytest = "^7.4.3"
 black = "^23.12.1"
 
+[tool.black]
+line-length = 88
+skip-string-normalization = true
+
+
 
 [build-system]
 requires = ["poetry-core"]
@@ -74,3 +79,27 @@ build-backend = "poetry.core.masonry.api"
 blackbox = 'blackbox.main:start'
 mantis-blackbox = 'blackbox.main:main'
 dzmitry_solver = 'simulation.routers.test_dzmitry:simulate'
+
+[tool.ruff]
+exclude = [
+    ".bzr",
+    ".devenv",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pytest_cache",
+    ".tox",
+    ".venv",
+    "build",
+    "dist",
+    "result",
+]
+
+
+line-length = 88
+indent-width = 4
+target-version = "py310"

--- a/mantis/simulation/orders/matching.py
+++ b/mantis/simulation/orders/matching.py
@@ -5,7 +5,6 @@ from objects import (
     OrderType,
     Solver,
     Solution,
-    CFMMSolver,
     CFMMVolumeSolver,
     CFMMProfitSolver,
     CFMM,

--- a/mantis/simulation/orders/objects.py
+++ b/mantis/simulation/orders/objects.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 from decimal import Decimal, getcontext
 import enum
 import random
-from typing import NewType, Callable, get_type_hints
+from typing import NewType, Callable
 from uuid import uuid4
 import copy
 from dataclasses import dataclass
 import functools
 import time
-from .routers import bruno_original_solver
 
 getcontext().prec = 18
 BuyToken = NewType("BuyToken", Decimal)

--- a/mantis/simulation/routers/data.py
+++ b/mantis/simulation/routers/data.py
@@ -1,13 +1,11 @@
 # for alignment on input and output of algorithm
 from fractions import Fraction
-from functools import cache
 import math
 import numpy as np
 import pandas as pd
 from enum import Enum
 from typing import TypeVar, Generic
 from pydantic import BaseModel, validator
-from methodtools import lru_cache
 
 # This is global unique ID for token(asset) or exchange(pool)
 TId = TypeVar("TId")

--- a/mantis/simulation/routers/dzmitry.py
+++ b/mantis/simulation/routers/dzmitry.py
@@ -7,7 +7,7 @@ import cvxpy as cp
 
 MAX_RESERVE = 1e10
 
-from simulation.routers.data import AllData, Input, TId, TNetworkId, Ctx
+from simulation.routers.data import AllData, Input, Ctx
 
 
 # prepares data for solving and outputs raw solution from underlying engine

--- a/mantis/simulation/routers/test_data.py
+++ b/mantis/simulation/routers/test_data.py
@@ -1,15 +1,7 @@
 # for alignment on input and output of algorithm
-from functools import cache
 from pathlib import Path
-import pandas as pd
-from enum import Enum
-from typing import TypeVar, Generic
-from pydantic import BaseModel, validator
-from strictly_typed_pandas import DataSet
 
 from mantis.simulation.routers.data import (
-    AssetPairsXyk,
-    AssetTransfers,
     new_data,
     new_pair,
     read_dummy_data,

--- a/mantis/simulation/routers/test_dzmitry.py
+++ b/mantis/simulation/routers/test_dzmitry.py
@@ -1,7 +1,5 @@
 # solves using convex optimization
 import numpy as np
-import cvxpy as cp
-from strictly_typed_pandas import DataSet
 
 MAX_RESERVE = 1e10
 
@@ -23,7 +21,7 @@ from simulation.routers.data import (
 import itertools
 import numpy as np
 
-from simulation.routers.dzmitry import solve, route
+from simulation.routers.dzmitry import route
 
 
 # simulate denom paths to and from chains, with center node

--- a/mantis/simulation/routers/test_stephon.py
+++ b/mantis/simulation/routers/test_stephon.py
@@ -1,11 +1,9 @@
 import itertools
 import numpy as np
 import cvxpy as cp
-import pandas as pd
 import random
 
 from typing import TypeVar, Tuple, Dict, List
-from tqdm import tqdm
 
 TAssetId = TypeVar("TAssetId")
 TNetworkId = TypeVar("TNetworkId")


### PR DESCRIPTION
blackbox\joiner.py:2:29: F401 [*] `blackbox.models.AllData` imported but unused
blackbox\joiner.py:3:18: F401 [*] `pandas` imported but unused
blackbox\joiner.py:21:5: F841 Local variable `asset` is assigned to but never used
blackbox\main.py:1:20: F401 [*] `typing.Dict` imported but unused
blackbox\main.py:6:57: F401 [*] `blackbox.cvm_runtime.response_to_get_config.GetConfigResponse` imported but unused
blackbox\main.py:9:5: F401 [*] `blackbox.models.CosmosChains` imported but unused
blackbox\main.py:10:5: F401 [*] `blackbox.models.NeutronPoolsResponse` imported but unused
blackbox\main.py:13:45: F401 [*] `blackbox.neutron_pools.Model` imported but unused
blackbox\main.py:16:50: F401 [*] `cosmpy.aerial.contract.LedgerContract` imported but unused
blackbox\main.py:18:38: F401 [*] `blackbox.cvm_runtime.query` imported but unused
blackbox\main.py:25:20: F401 [*] `typing.List` imported but unused
blackbox\main.py:27:18: F401 [*] `pandas` imported but unused
blackbox\main.py:83:5: F841 Local variable `client` is assigned to but never used
blackbox\playground.py:10:1: E402 Module level import not at top of file
blackbox\settings.py:1:22: F401 [*] `pydantic.BaseModel` imported but unused
blackbox\settings.py:2:45: F401 [*] `pydantic_settings.SettingsConfigDict` imported but unused
simulation\orders\matching.py:8:5: F401 [*] `objects.CFMMSolver` imported but unused
simulation\orders\matching.py:42:5: F841 Local variable `order_book` is assigned to but never used
simulation\orders\objects.py:5:39: F401 [*] `typing.get_type_hints` imported but unused
simulation\orders\objects.py:11:22: F401 [*] `.routers.bruno_original_solver` imported but unused
simulation\orders\objects.py:22:9: F841 Local variable `t1` is assigned to but never used
simulation\orders\objects.py:25:9: F841 Local variable `t2` is assigned to but never used
simulation\routers\bruno.py:7:1: E402 Module level import not at top of file
simulation\routers\bruno.py:40:52: E741 Ambiguous variable name: `l`
simulation\routers\bruno.py:43:53: E741 Ambiguous variable name: `l`
simulation\routers\data.py:3:23: F401 [*] `functools.cache` imported but unused
simulation\routers\data.py:10:25: F401 [*] `methodtools.lru_cache` imported but unused
simulation\routers\data.py:111:9: F811 Redefinition of unused `replace_nan_with_None` from line 87
simulation\routers\data.py:240:36: E711 Comparison to `None` should be `cond is not None`
simulation\routers\dzmitry.py:10:1: E402 Module level import not at top of file
simulation\routers\dzmitry.py:10:53: F401 [*] `simulation.routers.data.TId` imported but unused
simulation\routers\dzmitry.py:10:58: F401 [*] `simulation.routers.data.TNetworkId` imported but unused
simulation\routers\dzmitry.py:164:9: E722 Do not use bare `except`
simulation\routers\dzmitry.py:184:9: E722 Do not use bare `except`
simulation\routers\test_bruno.py:48:5: F841 Local variable `tol` is assigned to but never used
simulation\routers\test_bruno.py:120:24: F841 Local variable `l_max` is assigned to but never used
simulation\routers\test_bruno.py:120:31: F841 Local variable `p_max` is assigned to but never used
simulation\routers\test_bruno.py:122:9: E722 Do not use bare `except`
simulation\routers\test_bruno.py:136:20: E741 Ambiguous variable name: `l`
simulation\routers\test_bruno.py:149:9: E722 Do not use bare `except`
simulation\routers\test_data.py:2:23: F401 [*] `functools.cache` imported but unused
simulation\routers\test_data.py:4:18: F401 [*] `pandas` imported but unused
simulation\routers\test_data.py:5:18: F401 [*] `enum.Enum` imported but unused
simulation\routers\test_data.py:6:20: F401 [*] `typing.TypeVar` imported but unused
simulation\routers\test_data.py:6:29: F401 [*] `typing.Generic` imported but unused
simulation\routers\test_data.py:7:22: F401 [*] `pydantic.BaseModel` imported but unused
simulation\routers\test_data.py:7:33: F401 [*] `pydantic.validator` imported but unused
simulation\routers\test_data.py:8:35: F401 [*] `strictly_typed_pandas.DataSet` imported but unused
simulation\routers\test_data.py:11:5: F401 [*] `mantis.simulation.routers.data.AssetPairsXyk` imported but unused
simulation\routers\test_dzmitry.py:24:1: E402 Module level import not at top of file